### PR TITLE
Fix:Exposed Api_Key

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 # KEYS
 
-API_KEY=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
+API_KEY=""


### PR DESCRIPTION
I saw your Api_Key exposed and decided to send you
![imagen_2024-11-27_192303759](https://github.com/user-attachments/assets/f89496b4-c6dc-418b-99c3-6e64344d91e4)
  